### PR TITLE
fix: stat cards rendered vertically in repo page

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,6 @@ Yo!&nbsp; :wave: My name's **Daemon**, I like software.
 <!-- Statistics -->
 
 <div align=center>
-<a href="#"><img height="244px" src="https://raw.githubusercontent.com/daephx/github-stats/output/generated/overview.svg"/></a>
-<a href="#"><img height="244px" src="https://raw.githubusercontent.com/daephx/github-stats/output/generated/languages.svg"/></a>
+<a href="#"><img height="243px" src="https://raw.githubusercontent.com/daephx/github-stats/output/generated/overview.svg"/></a>
+<a href="#"><img height="243px" src="https://raw.githubusercontent.com/daephx/github-stats/output/generated/languages.svg"/></a>
 </div>

--- a/README.md
+++ b/README.md
@@ -30,6 +30,6 @@ Yo!&nbsp; :wave: My name's **Daemon**, I like software.
 <!-- Statistics -->
 
 <div align=center>
-<a href="#"><img height="245px" src="https://raw.githubusercontent.com/daephx/github-stats/output/generated/overview.svg"/></a>
-<a href="#"><img height="245px" src="https://raw.githubusercontent.com/daephx/github-stats/output/generated/languages.svg"/></a>
+<a href="#"><img height="244px" src="https://raw.githubusercontent.com/daephx/github-stats/output/generated/overview.svg"/></a>
+<a href="#"><img height="244px" src="https://raw.githubusercontent.com/daephx/github-stats/output/generated/languages.svg"/></a>
 </div>

--- a/README.md
+++ b/README.md
@@ -30,6 +30,6 @@ Yo!&nbsp; :wave: My name's **Daemon**, I like software.
 <!-- Statistics -->
 
 <div align=center>
-<a href="#"><img height="243px" src="https://raw.githubusercontent.com/daephx/github-stats/output/generated/overview.svg"/></a>
-<a href="#"><img height="243px" src="https://raw.githubusercontent.com/daephx/github-stats/output/generated/languages.svg"/></a>
+<a href="#"><img height="242px" src="https://raw.githubusercontent.com/daephx/github-stats/output/generated/overview.svg"/></a>
+<a href="#"><img height="242px" src="https://raw.githubusercontent.com/daephx/github-stats/output/generated/languages.svg"/></a>
 </div>

--- a/README.md
+++ b/README.md
@@ -30,6 +30,6 @@ Yo!&nbsp; :wave: My name's **Daemon**, I like software.
 <!-- Statistics -->
 
 <div align=center>
-<a href="#"><img height="242px" src="https://raw.githubusercontent.com/daephx/github-stats/output/generated/overview.svg"/></a>
-<a href="#"><img height="242px" src="https://raw.githubusercontent.com/daephx/github-stats/output/generated/languages.svg"/></a>
+<a href="#"><img height="240px" src="https://raw.githubusercontent.com/daephx/github-stats/output/generated/overview.svg"/></a>
+<a href="#"><img height="240px" src="https://raw.githubusercontent.com/daephx/github-stats/output/generated/languages.svg"/></a>
 </div>


### PR DESCRIPTION
The repo and profile readme sections have slightly different sizes. This is not a problem with the current values in the profile readme but does cause the stat cards to be stacked vertically when viewed from the repo itself.